### PR TITLE
Fix missing authentication when multiple private gitlab repos are referenced

### DIFF
--- a/src/main/scala/nl/zolotko/sbt/gitlab/GitlabPlugin.scala
+++ b/src/main/scala/nl/zolotko/sbt/gitlab/GitlabPlugin.scala
@@ -86,7 +86,8 @@ object GitlabPlugin extends AutoPlugin {
         .find(_.domain == repo.gitlabDomain)
         .fold(cfg)(token =>
           cfg.withAuthenticationByRepositoryId(
-            Vector(repo.resolverName -> Authentication("", "").withHeaders(Seq(token.key -> token.value)))
+            cfg.authenticationByRepositoryId :+
+              (repo.resolverName -> Authentication("", "").withHeaders(Seq(token.key -> token.value)))
           )
         )
     }


### PR DESCRIPTION
Fixes https://github.com/azolotko/sbt-gitlab/issues/57

Basically what the issue says + it is observed if using multiple gitlab repos